### PR TITLE
Update start-dev script to not auto-open browser; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-To start the API and UI together, use: `npm run start-dev`.
+To start the API and UI together, use: `npm run start-dev`. Then, access `http://localhost:3050` in your browser.
 
 ## UI
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "ts-node --project server/tsconfig.json server/app.ts",
     "heroku-postbuild": "npm run build",
-    "start-dev": "run-p start-server start-client",
+    "start-dev": "env BROWSER=false run-p start-server start-client",
     "start-client": "react-scripts start",
     "start-server": "ts-node-dev --project server/tsconfig.json server/app.ts",
     "build": "react-scripts build",


### PR DESCRIPTION
Because we're proxying in local development, no reason to auto-open port 3000 in your browser.