### PR TITLE
Ability to assign, unassign, and update the status of work

### DIFF
--- a/server/validators/index.ts
+++ b/server/validators/index.ts
@@ -1,0 +1,2 @@
+export { default as requestValidator } from './request';
+export { default as statusValidator } from './status';

--- a/server/validators/status.ts
+++ b/server/validators/status.ts
@@ -1,0 +1,10 @@
+import { Joi } from 'celebrate';
+
+const statusValidator = Joi.object().keys({
+  id: Joi.string().required(),
+  status: Joi.string()
+    .valid('Requested', 'Queued', 'Printing', 'Completed', 'Shipped')
+    .required(),
+});
+
+export default statusValidator;

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,3 +1,5 @@
+export const statuses = ['Requested', 'Queued', 'Printing', 'Completed', 'Shipped'];
+
 export const states = [
   'AL',
   'AK',

--- a/src/views/WorkView.tsx
+++ b/src/views/WorkView.tsx
@@ -14,7 +14,7 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
   const [work, setWork] = useState<Request[]>([]);
 
   function getWork() {
-    axios.get(buildEndpointUrl('requests/me')).then((res) => {
+    axios.get(buildEndpointUrl('requests/assigned')).then((res) => {
       setWork(res.data);
     });
   }
@@ -55,7 +55,7 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
 
   function assignWork(id: string) {
     axios
-      .put(buildEndpointUrl(`requests/${id}`))
+      .put(buildEndpointUrl(`requests/assign/${id}`))
       .then((res) => {
         refreshAll();
       })
@@ -68,7 +68,7 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
 
   function removeWork(id: string) {
     axios
-      .delete(buildEndpointUrl(`requests/${id}`))
+      .put(buildEndpointUrl(`requests/unassign/${id}`))
       .then((res) => {
         refreshAll();
       })

--- a/src/views/WorkView.tsx
+++ b/src/views/WorkView.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Button, ButtonGroup, Col, Dropdown, Row } from 'react-bootstrap';
 import axios from 'axios';
+import { find, indexOf } from 'lodash';
+import { toast } from 'react-toastify';
 
 import User from '../models/User';
 import Request from '../models/Request';
@@ -23,10 +25,63 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
     });
   }
 
-  // on load
-  useEffect(() => {
+  function refreshAll() {
     getWork();
     getAvailableWork();
+  }
+
+  function setStatus(id: string, status: string) {
+    axios
+      .patch(buildEndpointUrl(`requests/${id}/${status}`))
+      .then((res) => {
+        const work$ = [ ...work ];
+        const updated = find(work, f => f._id === id);
+        if (updated) {
+          const index = indexOf(work, updated)
+          work[index].status = status;
+          setWork(work$);
+        } else {
+          toast.error('ERROR', {
+            position: toast.POSITION.TOP_LEFT
+          });
+        }
+      })
+      .catch((err) => {
+        toast.error(`ERROR: ${err}`, {
+          position: toast.POSITION.TOP_LEFT
+        });
+      });
+  }
+
+  function assignWork(id: string) {
+    axios
+      .put(buildEndpointUrl(`requests/${id}`))
+      .then((res) => {
+        refreshAll();
+      })
+      .catch((err) => {
+        toast.error(`ERROR: ${err}`, {
+          position: toast.POSITION.TOP_LEFT
+        });
+      });
+  }
+
+  function removeWork(id: string) {
+    axios
+      .delete(buildEndpointUrl(`requests/${id}`))
+      .then((res) => {
+        refreshAll();
+      })
+      .catch((err) => {
+        toast.error(`ERROR: ${err}`, {
+          position: toast.POSITION.TOP_LEFT
+        });
+      });
+  }
+
+  // on load
+  useEffect(() => {
+    refreshAll();
   }, []);
 
   return (
@@ -73,30 +128,30 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
                             </Dropdown.Toggle>
 
                             <Dropdown.Menu>
-                              <Dropdown.Item>
+                              <Dropdown.Item onClick={() => setStatus(w._id, 'Requested')}>
                                 {StatusOption('Requested')}
                               </Dropdown.Item>
 
-                              <Dropdown.Item>
+                              <Dropdown.Item onClick={() => setStatus(w._id, 'Queued')}>
                                 {StatusOption('Queued')}
                               </Dropdown.Item>
 
-                              <Dropdown.Item>
+                              <Dropdown.Item onClick={() => setStatus(w._id, 'Printing')}>
                                 {StatusOption('Printing')}
                               </Dropdown.Item>
 
-                              <Dropdown.Item>
+                              <Dropdown.Item onClick={() => setStatus(w._id, 'Completed')}>
                                 {StatusOption('Completed')}
                               </Dropdown.Item>
 
-                              <Dropdown.Item>
+                              <Dropdown.Item onClick={() => setStatus(w._id, 'Shipped')}>
                                 {StatusOption('Shipped')}
                               </Dropdown.Item>
                             </Dropdown.Menu>
                           </Dropdown>
                         </td>
                         <td className="action">
-                          <Button variant="primary">{'{Action}'}</Button>
+                          <Button variant="primary" onClick={() => removeWork(w._id)}>Unassign</Button>
                         </td>
                       </tr>
                     );
@@ -142,7 +197,7 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
                         <td className="distance">X miles</td>
                         <td className="requestor">{w.facilityName}</td>
                         <td className="claim">
-                          <Button variant="primary">Claim</Button>
+                          <Button variant="primary" onClick={() => assignWork(w._id)}>Claim</Button>
                         </td>
                       </tr>
                     );

--- a/src/views/WorkView.tsx
+++ b/src/views/WorkView.tsx
@@ -8,6 +8,7 @@ import User from '../models/User';
 import Request from '../models/Request';
 import StatusOption from '../components/StatusOption';
 import { buildEndpointUrl } from '../utilities';
+import { statuses } from '../utilities/constants';
 
 const WorkView: React.FC<{ user: User }> = ({ user }) => {
   const [availableWork, setAvailableWork] = useState<Request[]>([]);
@@ -128,25 +129,11 @@ const WorkView: React.FC<{ user: User }> = ({ user }) => {
                             </Dropdown.Toggle>
 
                             <Dropdown.Menu>
-                              <Dropdown.Item onClick={() => setStatus(w._id, 'Requested')}>
-                                {StatusOption('Requested')}
-                              </Dropdown.Item>
-
-                              <Dropdown.Item onClick={() => setStatus(w._id, 'Queued')}>
-                                {StatusOption('Queued')}
-                              </Dropdown.Item>
-
-                              <Dropdown.Item onClick={() => setStatus(w._id, 'Printing')}>
-                                {StatusOption('Printing')}
-                              </Dropdown.Item>
-
-                              <Dropdown.Item onClick={() => setStatus(w._id, 'Completed')}>
-                                {StatusOption('Completed')}
-                              </Dropdown.Item>
-
-                              <Dropdown.Item onClick={() => setStatus(w._id, 'Shipped')}>
-                                {StatusOption('Shipped')}
-                              </Dropdown.Item>
+                              {statuses.map(status => (
+                                <Dropdown.Item onClick={() => setStatus(w._id, status)}>
+                                  {StatusOption(status)}
+                                </Dropdown.Item>
+                              ))}
                             </Dropdown.Menu>
                           </Dropdown>
                         </td>


### PR DESCRIPTION
End to end flow to:

- Assign yourself open work
- Unassign yourself work (resets the status)
- Change the status of assigned work
- Only displayed assigned work on the /work screen (don't show requests you created)
- Improve security by limiting fields a provider or printer can update to the request