### PR TITLE
Fallback to false for isSuperAdmin property

### DIFF
--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import Avatar from './Avatar';
 import navLogo from '../assets/img/navlogo.png';
 
 const MainNav: React.FC<{ user: User | undefined }> = ({ user }) => {
-  const showAdmin = get(user, 'isSuperAdmin', true);
+  const showAdmin = get(user, 'isSuperAdmin', false);
 
   return (
     <Navbar expand="lg" className="nav">


### PR DESCRIPTION
Displaying the Admin link was defaulting to `true` if `isSuperUser` was `undefined`.