### PR TITLE
Set google analytics key in the buildspec

### DIFF
--- a/configuration/buildspec.yml
+++ b/configuration/buildspec.yml
@@ -9,7 +9,7 @@ phases:
     commands:
       - echo Build started on `date`
       - cd ../api && npm run build
-      - cd ../ui && npm run build
+      - cd ../ui && REACT_APP_GA_KEY=UA-162138850-1 npm run build
   post_build:
     commands:
       - cd .. && mkdir output

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,3 +1,0 @@
-# This is only for storing the Google Analytics key, as it is already publicly available.
-# Do not store any sensitive secrets in this file.
-REACT_APP_GA_KEY=UA-162138850-1


### PR DESCRIPTION
Having trouble getting create-react-app to catch the environment variable... If this doesn't fix it we can hard-code.