### PR TITLE
Add "Other" as a job role

### DIFF
--- a/api/schemas/request.ts
+++ b/api/schemas/request.ts
@@ -5,6 +5,7 @@ import { IRequest } from '../interfaces';
 export const RequestSchema = new Schema({
   maskShieldCount: Number,
   jobRole: String,
+  otherJobRole: String,
   email: String,
   facilityName: String,
   addressLine1: String,

--- a/api/validators/request.ts
+++ b/api/validators/request.ts
@@ -6,8 +6,14 @@ const requestValidator = Joi.object().keys({
   maskShieldCount: Joi.number().required(),
   jobRole: Joi.string()
     .valid('Doctor', 'Nurse', 'First Responder', 'Medical Support Staff', 'Healthcare Worker', 'Critical Workforce',
-    'Delivery or Retail', 'Military')
+    'Delivery or Retail', 'Military', 'Other')
     .required(),
+  otherJobRole: Joi.string()
+    .when('jobRole', {
+      is: Joi.string().valid('Other'),
+      then: Joi.string().required(),
+      otherwise: Joi.string().allow('').optional(),
+  }),
   email: Joi.string().email().required(),
   facilityName: Joi.string().allow('').optional(),
   addressLine1: Joi.string().required(),

--- a/ui/src/models/Request.ts
+++ b/ui/src/models/Request.ts
@@ -2,6 +2,7 @@ export default interface Request {
   _id: string;
   maskShieldCount: number;
   jobRole: string;
+  otherJobRole?: string;
   email: string;
   facilityName?: string;
   addressLine1: string;

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -317,7 +317,7 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
                       <Form.Label>Other Job Role</Form.Label>
                       <Form.Control
                         disabled={disabled}
-                        required // Actually only required when detailsReq.jobRole === 'Other'
+                        required={detailsReq.jobRole === 'Other'}
                         type="text"
                         value={detailsReq.otherJobRole}
                         onChange={(e: BaseSyntheticEvent) =>

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -37,6 +37,7 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
     maskShieldCount: 1,
     details: '',
     jobRole: '',
+    otherJobRole: '',
     email: '',
     facilityName: '',
     addressLine1: '',
@@ -64,7 +65,8 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
     'First Responder',
     'Critical Workforce',
     'Delivery or Retail',
-    'Military'
+    'Military',
+    'Other'
   ];
 
   const getDetails = () => {
@@ -105,6 +107,7 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
         'maskShieldCount',
         'details',
         'jobRole',
+        'otherJobRole',
         'email',
         'facilityName',
         'addressLine1',
@@ -287,7 +290,8 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
                     required
                     value={detailsReq.jobRole}
                     onChange={(e: BaseSyntheticEvent) =>
-                      updateDetailsReq({ jobRole: e.target.value })
+                      // reset otherJobRole on change
+                      updateDetailsReq({ jobRole: e.target.value, otherJobRole: '' })
                     }
                   >
                     <option value={''}>Select your Role</option>
@@ -296,6 +300,22 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
                     })}
                   </Form.Control>
                 </Form.Group>
+
+                {
+                  detailsReq.jobRole === 'Other' &&
+                    <Form.Group controlId="formBasicOtherRole">
+                      <Form.Label>Other Job Role</Form.Label>
+                      <Form.Control
+                        disabled={disabled}
+                        required // Actually only required when detailsReq.jobRole === 'Other'
+                        type="text"
+                        value={detailsReq.otherJobRole}
+                        onChange={(e: BaseSyntheticEvent) =>
+                          updateDetailsReq({ otherJobRole: e.target.value })
+                        }
+                      />
+                    </Form.Group>
+                }
 
                 <Form.Group controlId="formBasicEmail">
                   <Form.Label>Preferred Email Address</Form.Label>

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -317,7 +317,7 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
                       <Form.Label>Other Job Role</Form.Label>
                       <Form.Control
                         disabled={disabled}
-                        required={detailsReq.jobRole === 'Other'}
+                        required // Actually only required when detailsReq.jobRole === 'Other'
                         type="text"
                         value={detailsReq.otherJobRole}
                         onChange={(e: BaseSyntheticEvent) =>


### PR DESCRIPTION
Adds "Other" as a job role in the New Request form. Conditionally displays a text box for the user to enter their role. This field is required if the user selects "Other", otherwise it is optional (and even display in the form).

<img width="582" alt="Screen Shot 2020-04-11 at 12 44 44 PM" src="https://user-images.githubusercontent.com/11576347/79049561-582f0500-7bf2-11ea-9af5-30694edf23ba.png">
