### PR TITLE
Update shield count input

### DIFF
--- a/api/validators/request.ts
+++ b/api/validators/request.ts
@@ -3,7 +3,7 @@ import { Joi } from 'celebrate';
 import { states } from '../constants';
 
 const requestValidator = Joi.object().keys({
-  maskShieldCount: Joi.number().required(),
+  maskShieldCount: Joi.number().min(1).max(10000).required(),
   jobRole: Joi.string()
     .valid(
       'Doctor',

--- a/ui/src/assets/scss/05-components/_new-request.scss
+++ b/ui/src/assets/scss/05-components/_new-request.scss
@@ -13,6 +13,7 @@
 #requested-mask-shields-card {
   height: 150px;
   font-size: 50px;
+  max-width: 100%;
   padding-left: 60px;
 }
 

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -233,7 +233,7 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
       ) : (
         <>
           <Row id="requested-row-1">
-            <Col>
+            <Col xs={6}>
               <h4>Request Submitted By</h4>
               <Card bg="light" id="requested-by-card">
                 <Card.Body>
@@ -259,26 +259,37 @@ const RequestFormView: React.FC<{ user: User }> = ({ user }) => {
               </Card>
             </Col>
 
-            <Col>
+            <Col xs={6}>
               <h4>Number Requested</h4>
               <Form>
                 <Form.Group>
                   <Form.Control
+                    required
                     disabled={disabled}
-                    as="select"
+                    type="number"
                     size="lg"
                     custom
                     id="requested-mask-shields-card"
                     value={detailsReq.maskShieldCount}
-                    onChange={(e: BaseSyntheticEvent) =>
-                      updateDetailsReq({ maskShieldCount: e.target.value })
-                    }
-                  >
-                    <option>1</option>
-                    <option>2</option>
-                  </Form.Control>
+                    onChange={(e: BaseSyntheticEvent) => {
+                      // Allow range of 0 to 10000. 0 will still cause server-side error,
+                      // but makes the number input easier to change.
+                      let value = e.target.value;
+                      if (value < 0) value = 0;
+                      if (value > 10000) value = 10000;
+                      updateDetailsReq({ maskShieldCount: value })
+                    }}
+                  />
                 </Form.Group>
               </Form>
+              {
+                detailsReq.maskShieldCount >= 50 && !isExisting &&
+                  <Alert variant="info">
+                    For this request size, you will also need to email us
+                    at <a href="mailto:Jeffrey@CollectiveShield.org">Jeffrey@CollectiveShield.org</a> after
+                    you submit your request.
+                  </Alert>
+              }
             </Col>
           </Row>
 


### PR DESCRIPTION
- Use open number field
- Must be positive number less than or equal to 10,000
- Display an alert if they want to request 50 or more
- `0` is allowed on front-end to allow the user to easily update the field, but a minimum of `1` is required on the server.

<img width="1144" alt="Screen Shot 2020-04-12 at 1 40 48 PM" src="https://user-images.githubusercontent.com/11576347/79075862-5b45f600-7cc3-11ea-9521-b7105d5a4a72.png">


Alert if 50 or more:
<img width="599" alt="Screen Shot 2020-04-12 at 1 41 00 PM" src="https://user-images.githubusercontent.com/11576347/79075867-5da85000-7cc3-11ea-93b8-0d684c70e930.png">
