### PR TITLE
Update/maker notes

### DIFF
--- a/api/controllers/requests.ts
+++ b/api/controllers/requests.ts
@@ -152,6 +152,8 @@ export default class RequestsController {
       });
   }
 
+  // TODO - update to allow /maker-details to accept only necessary fields
+  // https://github.com/ConnorDY/collective-shield/pull/117#issuecomment-614034590
   @Patch('/:id/maker-details')
   patchMakerNotesById(
     @Param('id') id: string,

--- a/api/controllers/requests.ts
+++ b/api/controllers/requests.ts
@@ -12,6 +12,7 @@ import {
 } from 'routing-controllers';
 import { MongooseFilterQuery } from 'mongoose';
 import { celebrate, Segments } from 'celebrate';
+import { omit, pick } from 'lodash';
 
 import config from '../config';
 import { Request } from '../schemas';
@@ -138,10 +139,29 @@ export default class RequestsController {
     @CurrentUser() user: IUser,
     @Body() body: IRequest
   ) {
-    // Requestor can update any field
+    // Requestor can update any field, except makerNotes
     return Request.findOneAndUpdate(
       { _id: id, requestorID: user._id },
-      { $set: body }
+      { $set: omit(body, ['makerNotes']) }
+    )
+      .then((result) => {
+        return result;
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+
+  @Patch('/:id/maker-details')
+  patchMakerNotesById(
+    @Param('id') id: string,
+    @CurrentUser() user: IUser,
+    @Body() body: IRequest
+  ) {
+    // Maker can only update makerNotes
+    return Request.findOneAndUpdate(
+      { _id: id, makerID: user._id },
+      { $set: pick(body, ['makerNotes']) }
     )
       .then((result) => {
         return result;

--- a/api/interfaces/request.ts
+++ b/api/interfaces/request.ts
@@ -18,4 +18,5 @@ export default interface Request extends Document {
   makerID?: string;
   requestorID: string;
   homePickUp: boolean;
+  makerNotes?: string;
 }

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "http-proxy-middleware": "^1.0.3",
+    "lodash": "^4.17.15",
     "mailgun-js": "^0.22.0",
     "mongoose": "^5.9.6",
     "multer": "^1.4.2",

--- a/api/schemas/request.ts
+++ b/api/schemas/request.ts
@@ -23,7 +23,8 @@ export const RequestSchema = new Schema(
     status: String,
     updateDate: Date,
     requestorID: String,
-    homePickUp: Boolean
+    homePickUp: Boolean,
+    makerNotes: String,
   },
   { toJSON: { virtuals: true } }
 );

--- a/api/validators/request.ts
+++ b/api/validators/request.ts
@@ -36,6 +36,7 @@ const requestValidator = Joi.object().keys({
   phone: Joi.string().required(),
   details: Joi.string().allow('').optional(),
   homePickUp: Joi.boolean().required(),
+  makerNotes: Joi.string().allow('').optional(),
 });
 
 export default requestValidator;

--- a/ui/src/models/Request.ts
+++ b/ui/src/models/Request.ts
@@ -24,4 +24,5 @@ export default interface Request {
   maker?: User;
   requestor?: User;
   homePickUp: boolean;
+  makerNotes?: string;
 }

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -123,6 +123,8 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
         'homePickUp',
         'makerNotes',
       ]);
+      // TODO - update to allow /maker-details to accept only necessary fields
+      // https://github.com/ConnorDY/collective-shield/pull/117#issuecomment-614034590
 
       const endpoint = isMakerView ? `requests/${id}/maker-details` : 'requests';
       const method = isMakerView ? 'patch' : 'post';

--- a/ui/src/views/RequestFormView.tsx
+++ b/ui/src/views/RequestFormView.tsx
@@ -54,7 +54,8 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
     status: '',
     makerID: '',
     requestorID: '',
-    homePickUp: false
+    homePickUp: false,
+    makerNotes: ''
   });
 
   const roleOptions = [
@@ -120,13 +121,23 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
         'addressZip',
         'phone',
         'homePickUp',
+        'makerNotes',
       ]);
 
+      const endpoint = isMakerView ? `requests/${id}/maker-details` : 'requests';
+      const method = isMakerView ? 'patch' : 'post';
+
       axios
-        .post(buildEndpointUrl('requests'), data)
+        [method](buildEndpointUrl(endpoint), data)
         .then(() => {
-          setIsCreated(true);
-          scrollToTop();
+          if (isMakerView) {
+            toast.success('Successfully updated!', {
+              position: toast.POSITION.TOP_LEFT
+            });
+          } else {
+            setIsCreated(true);
+            scrollToTop();
+          }
         })
         .catch((err) => {
           toast.error(err.toString(), {
@@ -503,19 +514,22 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
                   </Form.Group>
                 </Form>
 
-                {!isExisting && (
+                {(!isExisting || isMakerView) && (
                   <div id="request-button-group">
                     <Button variant="primary" type="submit">
-                      Submit Request
+                      {isExisting ? 'Update Request' : 'Submit Request'}
                     </Button>
 
-                    <Button
-                      variant="light"
-                      id="cancel-request-button"
-                      onClick={cancel}
-                    >
-                      Cancel Request
-                    </Button>
+                    {
+                      !isExisting &&
+                        <Button
+                          variant="light"
+                          id="cancel-request-button"
+                          onClick={cancel}
+                        >
+                          Cancel Request
+                        </Button>
+                    }
                   </div>
                 )}
               </Form>
@@ -525,11 +539,11 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
               <h4>Request Details</h4>
               <h5>Add any details or comments about the request here</h5>
               <Form>
-                <Form.Group controlId="">
+                <Form.Group controlId="requestDetails">
                   <Form.Control
                     disabled={disabled}
                     as="textarea"
-                    rows="13"
+                    rows="11"
                     value={detailsReq.details}
                     onChange={(e: BaseSyntheticEvent) =>
                       updateDetailsReq({ details: e.target.value })
@@ -537,6 +551,33 @@ const RequestFormView: React.FC<{ user: User; role: string }> = ({
                   />
                 </Form.Group>
               </Form>
+
+              {
+                isExisting &&
+                <>
+                  <h4>Maker Notes</h4>
+                  <h5>Makers can add notes here, which are also visible to the requester</h5>
+                  <Form>
+                    <Form.Group controlId="requestMakerNotes">
+                      <Form.Control
+                        disabled={disabled && !isMakerView}
+                        as="textarea"
+                        rows="9"
+                        value={detailsReq.makerNotes}
+                        onChange={(e: BaseSyntheticEvent) =>
+                          updateDetailsReq({ makerNotes: e.target.value })
+                        }
+                      />
+                    </Form.Group>
+                  </Form>
+                  {
+                    isMakerView &&
+                      <Alert variant="info">
+                        Ensure that you click the "Update Request" button when are you done updating notes.
+                      </Alert>
+                  }
+                </>
+              }
             </Col>
           </Row>
         </>


### PR DESCRIPTION
~~Relies on #116~~

Adds the ability for the maker assigned to a request to update the new `makerNotes` field on the request. This is the only field (other than status) a maker is able to update. The requester can see these notes, but not modify them.

Could use some feedback on the new `PATCH` route. Even though this could have been included in the existing route, I wanted to keep the logic separate when updating as a maker versus updating as a requester.

View as a maker:
<img width="1176" alt="Screen Shot 2020-04-14 at 7 55 16 PM" src="https://user-images.githubusercontent.com/11576347/79284972-220bb280-7e8a-11ea-9c06-ab52b1d371b4.png">

View as requester (this field is hidden when in the New Request view):
<img width="1200" alt="Screen Shot 2020-04-14 at 7 55 29 PM" src="https://user-images.githubusercontent.com/11576347/79284999-38197300-7e8a-11ea-879f-9cd302b9cfa6.png">
