### PR TITLE
adds missing search keys

### DIFF
--- a/ui/src/views/RequestListView.tsx
+++ b/ui/src/views/RequestListView.tsx
@@ -36,7 +36,11 @@ const RequestListView: React.FC<{}> = () => {
       'addressState',
       'addressZip',
       'requestorID',
-      'makerID'
+      'makerID',
+      'firstName',
+      'lastName',
+      'maker.firstName',
+      'maker.lastName'
     ];
 
     const results = allRequests.filter((m) => {


### PR DESCRIPTION
Search results now include requester first name and last name as well as the printer's first name and last name.
<img width="1221" alt="Screen Shot 2020-04-16 at 4 52 34 PM" src="https://user-images.githubusercontent.com/17617685/79505939-28716a00-8003-11ea-8764-387d634c41e1.png">
